### PR TITLE
おつぎのかたふたたび

### DIFF
--- a/src/pic/templates/admin.html
+++ b/src/pic/templates/admin.html
@@ -92,12 +92,16 @@ input[type=text]{
     {% block images %}
     <div class="pagination">
         <span class="step-links">
+			{% if contacts.has_previous %}
 			<a href="?page={{ contacts.previous_page_number }}&{{ nextparams }}"> <前 </a>
-
+			{% endif %}
             {% for n in contacts.paginator.page_range|pagelist:contacts.number %}
                 <a href="?page={{ n }}&{{ nextparams }}">{{ n }}</a>
             {% endfor %}
+			{% if contacts.has_next %}
 			<a href="?page={{ contacts.next_page_number }}&{{ nextparams }}"> 次> </a>
+			{% endif %}
+
         </span>
     </div>
     <div class="body">
@@ -111,12 +115,14 @@ input[type=text]{
             <img src="/thumbnail/{{ image.filename }}"/>
         </a>
     {% endfor %}
+	{% if contacts.has_next %}
 		<a href="?page={{ contacts.next_page_number }}&{{ nextparams }}"
 		   class="popup" rel="image"
 		   data-tags="" data-key="-1"
 		   data-title="" id="next-page">
 			<img src="data:image/gif;base64,R0lGODdhLAEsAYAAAM8cAP7+/iwAAAAALAEsAQAC/4yPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gvH8kzX9o3n+s73/g8MCofEovGITCqXzKbzCY1Kp9Sq9YrNarfcrvcLDovH5LL5jE6r1+y2+w2Py+f0uv2Oz+v3/L7/DxgoOEhYaHiImKi4yNjo+AgZKTlJWWl5iZmpucnZ6fkJGio6SlpqeoqaqrrK2ur6ChsrO0tba3uLm6u7y9vr+wscLDxMXGx8jJysvMzc7PwMHS09TV1tfY2drb3N3e39DR4uPk5ebn6Onq6+zt7u/g4fLz9PX29/j5+vv8/f7/8PMKDAgQQLGkQBICGAgykUOmRIwqHEhRBBTExYUcTEjP8jJHJUgDHDxo8JFGLwSBLkQwooU5ZcGWGky5cwHbTcQJGfzAY3RYbcd9FmTZ8mde6k+ZPoUHxHEVx8CjVqUaBLDUi9inVqvp4Hql6IajRpV60aggIkaxXtSa5GF3i10NSg2gA5J7At6NUsz7cE59LV69ZvX7FIBfMd/CCuU8IMBf/le1ig48eGGR+0XLguTZKYM/NM2dmzW5eaE5ssPdMmg4ehU89FiTp1WsywZRc2XbR1Y8WLc8eG+FRCzd94gwsfTvws1Ao3dW+9Chd58udgo6N1fm/52uvY6wG2zjhydvG4LU8ePz3mW/Le00O4O9s9ve6rD8OfeX/s+Yy8e+/VB85ef/yxR9l/gxkYH4L/CLgXgwE52CCEYdFXn3EHKhihhQsSeJxU/kjIXHVUcQgeiezk98F39qCokYnnuJiifOpgaFuNNt6IY4467shjjz7+CGSQQg5JZJFGHolkkkouyWSTTj4JZZRSTklllVZeiWWWWm7JZZdefglmmGKOSWaZZp6JZppqrslmm26+CWeccs5JZ5123olnnnruyWeffv4JaKCCDkpooYYeimiiii7KaKOOPgpppJJOSmmlll6Kaaaabsppp55+Cmqooo5Kaqmm9lEAADs= ">
 		</a>
+	{% endif %}
     </div>
     {% endblock %}
 </div>

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -18,15 +18,25 @@ $(function(){
     function before_fancy_start(currentArray, currentIndex, currentOpts){
 		var $x = $(currentArray[currentIndex]);
 
+		// key==-1 <=> 「次」
 		if($x.data("key") == -1) { 
-			window.location = $x.attr("href") + "#next";
-		}
-		
-        var title = '<div id="title" data-key="' + $x.data("key") + '">'
+			var hasNext = "";
+
+			// もし前の画像からの遷移で来たならば
+			// 次のページには#nextをつける
+			if($("#title").length != 0) {
+				hasNext = "#next";
+			}
+
+			window.location = $x.attr("href") + hasNext;
+			$.fancybox.close();
+		} else {
+			var title = '<div id="title" data-key="' + $x.data("key") + '">'
 				+ $x.data("tags").replace(/,/g, '&nbsp;&nbsp;')
 				+ '&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;'
 				+ $x.data("title") + '</div>';
-		$x.attr("title", title);
+			$x.attr("title", title);
+		}
     }
 
     function set_titles(){
@@ -204,7 +214,7 @@ $(function(){
 	});
 
 	if(document.location.hash == "#next") {
-		$(".image-pic").get(0).click();
+		$(".image-pic:nth(0)").click();
 	}
 });
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -215,6 +215,7 @@ $(function(){
 
 	if(document.location.hash == "#next") {
 		$(".image-pic:nth(0)").click();
+		window.location.hash = "";
 	}
 });
 


### PR DESCRIPTION
・最初と最後のページで"<前"、"次>"が表示されなくなった
・次画像は最後のページには表示されない
・自動で次のページのfancyboxを開く機能(fancy-page-crossing-box)の修正
→ 直接「次」を押せば次のページでは開かれない
→ fancy-page-crossing-box発動後にページ更新しても2度目は起きない
